### PR TITLE
feat: 회원가입 기능을 구현한다

### DIFF
--- a/src/main/java/com/vestie/vestie/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/vestie/vestie/common/exception/ExceptionControllerAdvice.java
@@ -31,7 +31,7 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(BaseException.class)
     ResponseEntity<ExceptionResponse> handleException(BaseException e) {
         BaseExceptionType type = e.exceptionType();
-        log.warn("[WARM] 예외 내용: {}", type.errorMessage());
+        log.warn("[WARN] 예외 내용: {}", type.errorMessage());
         return new ResponseEntity<>(
                 new ExceptionResponse(String.valueOf(type.errorCode()), type.errorMessage()),
                 type.httpStatus());

--- a/src/main/java/com/vestie/vestie/member/application/MemberService.java
+++ b/src/main/java/com/vestie/vestie/member/application/MemberService.java
@@ -1,0 +1,24 @@
+package com.vestie.vestie.member.application;
+
+import com.vestie.vestie.member.application.dto.SignUpCommand;
+import com.vestie.vestie.member.domain.Member;
+import com.vestie.vestie.member.domain.MemberRepository;
+import com.vestie.vestie.member.domain.MemberValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberValidator memberValidator;
+
+    public void signUp(SignUpCommand command) {
+        Member member = command.toDomain();
+        member.signUp(memberValidator);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/vestie/vestie/member/application/dto/SignUpCommand.java
+++ b/src/main/java/com/vestie/vestie/member/application/dto/SignUpCommand.java
@@ -1,0 +1,17 @@
+package com.vestie.vestie.member.application.dto;
+
+import com.vestie.vestie.member.domain.Member;
+
+public record SignUpCommand(
+        String username,
+        String password,
+        String name
+) {
+    public Member toDomain() {
+        return Member.builder()
+                .username(username)
+                .password(password)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/vestie/vestie/member/domain/Member.java
+++ b/src/main/java/com/vestie/vestie/member/domain/Member.java
@@ -35,4 +35,8 @@ public class Member extends BaseEntity {
     public String name() {
         return name;
     }
+
+    public void signUp(MemberValidator validator) {
+        validator.validateDuplicateUsername(username);
+    }
 }

--- a/src/main/java/com/vestie/vestie/member/domain/MemberRepository.java
+++ b/src/main/java/com/vestie/vestie/member/domain/MemberRepository.java
@@ -3,12 +3,16 @@ package com.vestie.vestie.member.domain;
 import static com.vestie.vestie.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 
 import com.vestie.vestie.member.exception.MemberException;
-import jakarta.annotation.Nonnull;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository {
 
-    @Nonnull
+    Member save(Member member);
+
+    boolean existsByUsername(String username);
+
+    Optional<Member> findById(Long id);
+
     default Member getById(Long id) {
         return findById(id)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));

--- a/src/main/java/com/vestie/vestie/member/domain/MemberValidator.java
+++ b/src/main/java/com/vestie/vestie/member/domain/MemberValidator.java
@@ -1,0 +1,20 @@
+package com.vestie.vestie.member.domain;
+
+import static com.vestie.vestie.member.exception.MemberExceptionType.DUPLICATE_USERNAME;
+
+import com.vestie.vestie.member.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberValidator {
+
+    private final MemberRepository memberRepository;
+
+    public void validateDuplicateUsername(String username) {
+        if (memberRepository.existsByUsername(username)) {
+            throw new MemberException(DUPLICATE_USERNAME);
+        }
+    }
+}

--- a/src/main/java/com/vestie/vestie/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/vestie/vestie/member/exception/MemberExceptionType.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberExceptionType implements BaseExceptionType {
 
     NOT_FOUND_MEMBER(100, HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."),
-    ;
+    DUPLICATE_USERNAME(101, HttpStatus.CONFLICT, "이미 존재하는 아이디입니다.");
 
     private final int errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/vestie/vestie/member/infrastructure/persistence/JpaMemberRepository.java
+++ b/src/main/java/com/vestie/vestie/member/infrastructure/persistence/JpaMemberRepository.java
@@ -1,0 +1,15 @@
+package com.vestie.vestie.member.infrastructure.persistence;
+
+import com.vestie.vestie.member.domain.Member;
+import com.vestie.vestie.member.domain.MemberRepository;
+import jakarta.annotation.Nonnull;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMemberRepository extends MemberRepository, JpaRepository<Member, Long> {
+
+    @Nonnull
+    @Override
+    default Member getById(Long id) {
+        return MemberRepository.super.getById(id);
+    }
+}

--- a/src/main/java/com/vestie/vestie/member/presentation/MemberController.java
+++ b/src/main/java/com/vestie/vestie/member/presentation/MemberController.java
@@ -1,0 +1,30 @@
+package com.vestie.vestie.member.presentation;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.vestie.vestie.member.application.MemberService;
+import com.vestie.vestie.member.presentation.dto.SignUpRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    ResponseEntity<Void> signUp(
+            @Valid @RequestBody SignUpRequest request
+    ) {
+        memberService.signUp(request.toCommand());
+        return ResponseEntity.status(CREATED)
+                .build();
+    }
+}

--- a/src/main/java/com/vestie/vestie/member/presentation/dto/SignUpRequest.java
+++ b/src/main/java/com/vestie/vestie/member/presentation/dto/SignUpRequest.java
@@ -1,0 +1,15 @@
+package com.vestie.vestie.member.presentation.dto;
+
+import com.vestie.vestie.member.application.dto.SignUpCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignUpRequest(
+        @NotBlank String username,
+        @NotBlank String password,
+        @NotBlank String name
+) {
+
+    public SignUpCommand toCommand() {
+        return new SignUpCommand(username, password, name);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
         highlight_sql: true
         default_batch_fetch_size: 100
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create-drop
 
 logging:
   level:

--- a/src/test/java/com/vestie/vestie/acceptance/common/AcceptanceTest.java
+++ b/src/test/java/com/vestie/vestie/acceptance/common/AcceptanceTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @ExtendWith(DataClearExtension.class)
-@SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public abstract class AcceptanceTest {
 

--- a/src/test/java/com/vestie/vestie/acceptance/common/AcceptanceTest.java
+++ b/src/test/java/com/vestie/vestie/acceptance/common/AcceptanceTest.java
@@ -1,0 +1,23 @@
+package com.vestie.vestie.acceptance.common;
+
+import com.vestie.vestie.common.DataClearExtension;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@ExtendWith(DataClearExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/com/vestie/vestie/acceptance/common/CommonAcceptanceSteps.java
+++ b/src/test/java/com/vestie/vestie/acceptance/common/CommonAcceptanceSteps.java
@@ -1,0 +1,45 @@
+package com.vestie.vestie.acceptance.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.vestie.vestie.common.exception.BaseExceptionType;
+import com.vestie.vestie.common.exception.ExceptionResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.springframework.http.HttpStatus;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class CommonAcceptanceSteps {
+
+    public static HttpStatus 정상_처리 = HttpStatus.OK;
+    public static HttpStatus 생성됨 = HttpStatus.CREATED;
+    public static HttpStatus 잘못된_요청 = HttpStatus.BAD_REQUEST;
+    public static HttpStatus 권한_없음 = HttpStatus.FORBIDDEN;
+    public static HttpStatus 찾을수_없음 = HttpStatus.NOT_FOUND;
+    public static HttpStatus 중복됨 = HttpStatus.CONFLICT;
+
+    public static RequestSpecification given() {
+        return RestAssured
+                .given().log().all()
+                .contentType(APPLICATION_JSON_VALUE);
+    }
+
+    public static void 응답_상태를_검증한다(ExtractableResponse<Response> 응답, HttpStatus 상태) {
+        assertThat(응답.statusCode())
+                .isEqualTo(상태.value());
+    }
+
+    public static void 발생한_예외를_검증한다(
+            ExtractableResponse<Response> 응답,
+            BaseExceptionType 예외_타입
+    ) {
+        ExceptionResponse exceptionResponse = 응답.as(ExceptionResponse.class);
+        assertThat(exceptionResponse.code())
+                .isEqualTo(String.valueOf(예외_타입.errorCode()));
+        assertThat(exceptionResponse.message())
+                .isEqualTo(예외_타입.errorMessage());
+    }
+}

--- a/src/test/java/com/vestie/vestie/acceptance/member/MemberAcceptanceSteps.java
+++ b/src/test/java/com/vestie/vestie/acceptance/member/MemberAcceptanceSteps.java
@@ -1,0 +1,25 @@
+package com.vestie.vestie.acceptance.member;
+
+import static com.vestie.vestie.acceptance.common.CommonAcceptanceSteps.given;
+
+import com.vestie.vestie.member.presentation.dto.SignUpRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 회원_가입_요청(
+            String 아이디,
+            String 비밀번호,
+            String 이름
+    ) {
+        SignUpRequest 회원_가입_요청_데이터 = new SignUpRequest(아이디, 비밀번호, 이름);
+        return given()
+                .body(회원_가입_요청_데이터)
+                .when()
+                .post("/members")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/vestie/vestie/acceptance/member/MemberAcceptanceTest.java
+++ b/src/test/java/com/vestie/vestie/acceptance/member/MemberAcceptanceTest.java
@@ -1,0 +1,44 @@
+package com.vestie.vestie.acceptance.member;
+
+import static com.vestie.vestie.acceptance.common.CommonAcceptanceSteps.생성됨;
+import static com.vestie.vestie.acceptance.common.CommonAcceptanceSteps.응답_상태를_검증한다;
+import static com.vestie.vestie.acceptance.common.CommonAcceptanceSteps.중복됨;
+import static com.vestie.vestie.acceptance.member.MemberAcceptanceSteps.회원_가입_요청;
+
+import com.vestie.vestie.acceptance.common.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("회원 인수 테스트")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Nested
+    class 회원_가입_시 {
+
+        @Test
+        void 아이디가_중복되지_않으면_가입된다() {
+            // when
+            var 회원_가입_응답 = 회원_가입_요청("mallang", "1234", "동훈");
+
+            // then
+            응답_상태를_검증한다(회원_가입_응답, 생성됨);
+        }
+
+        @Test
+        void 아이디가_중복되면_가입되지_않는다() {
+            // given
+            회원_가입_요청("vestie", "1234", "동훈");
+
+            // when
+            var 응답 = 회원_가입_요청("vestie", "12345", "미래");
+
+            // then
+            응답_상태를_검증한다(응답, 중복됨);
+        }
+    }
+}

--- a/src/test/java/com/vestie/vestie/common/DataCleaner.java
+++ b/src/test/java/com/vestie/vestie/common/DataCleaner.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Profile("test")
 public class DataCleaner {
 
-    private static final String REFERENTIAL_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
+    private static final String FOREIGN_KEY_CHECK_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
     private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
 
     private final List<String> tableNames = new ArrayList<>();
@@ -24,7 +24,7 @@ public class DataCleaner {
     @PostConstruct
     @SuppressWarnings("unchecked")
     public void findDatabaseTableNames() {
-        List<Object[]> tableInfos = entityManager.createNativeQuery("show tables").getResultList();
+        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
         for (Object[] tableInfo : tableInfos) {
             String tableName = (String) tableInfo[0];
             tableNames.add(tableName);
@@ -38,10 +38,10 @@ public class DataCleaner {
     }
 
     private void truncate() {
-        entityManager.createNativeQuery(String.format(REFERENTIAL_FORMAT, 0)).executeUpdate();
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 0)).executeUpdate();
         for (String tableName : tableNames) {
             entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
         }
-        entityManager.createNativeQuery(String.format(REFERENTIAL_FORMAT, 1)).executeUpdate();
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECK_FORMAT, 1)).executeUpdate();
     }
 }

--- a/src/test/java/com/vestie/vestie/common/DataCleaner.java
+++ b/src/test/java/com/vestie/vestie/common/DataCleaner.java
@@ -16,10 +16,10 @@ public class DataCleaner {
     private static final String REFERENTIAL_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
     private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
 
+    private final List<String> tableNames = new ArrayList<>();
+
     @PersistenceContext
     private EntityManager entityManager;
-
-    private List<String> tableNames = new ArrayList<>();
 
     @PostConstruct
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/vestie/vestie/common/DataCleaner.java
+++ b/src/test/java/com/vestie/vestie/common/DataCleaner.java
@@ -1,0 +1,47 @@
+package com.vestie.vestie.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@Component
+public class DataCleaner {
+
+    private static final String REFERENTIAL_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
+    private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames = new ArrayList<>();
+
+    @SuppressWarnings("unchecked")
+    @PostConstruct
+    public void findDatabaseTableNames() {
+        List<Object[]> tableInfos = entityManager.createNativeQuery("show tables").getResultList();
+        for (Object[] tableInfo : tableInfos) {
+            String tableName = (String) tableInfo[0];
+            tableNames.add(tableName);
+        }
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        truncate();
+    }
+
+    private void truncate() {
+        entityManager.createNativeQuery(String.format(REFERENTIAL_FORMAT, 0)).executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format(REFERENTIAL_FORMAT, 1)).executeUpdate();
+    }
+}

--- a/src/test/java/com/vestie/vestie/common/DataCleaner.java
+++ b/src/test/java/com/vestie/vestie/common/DataCleaner.java
@@ -9,8 +9,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Profile("test")
 @Component
+@Profile("test")
 public class DataCleaner {
 
     private static final String REFERENTIAL_FORMAT = "SET FOREIGN_KEY_CHECKS %d";
@@ -21,8 +21,8 @@ public class DataCleaner {
 
     private List<String> tableNames = new ArrayList<>();
 
-    @SuppressWarnings("unchecked")
     @PostConstruct
+    @SuppressWarnings("unchecked")
     public void findDatabaseTableNames() {
         List<Object[]> tableInfos = entityManager.createNativeQuery("show tables").getResultList();
         for (Object[] tableInfo : tableInfos) {

--- a/src/test/java/com/vestie/vestie/common/DataClearExtension.java
+++ b/src/test/java/com/vestie/vestie/common/DataClearExtension.java
@@ -1,13 +1,13 @@
 package com.vestie.vestie.common;
 
-import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-public class DataClearExtension implements AfterEachCallback {
+public class DataClearExtension implements BeforeEachCallback {
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void beforeEach(ExtensionContext context) {
         DataCleaner dataCleaner = getDataCleaner(context);
         dataCleaner.clear();
     }

--- a/src/test/java/com/vestie/vestie/common/DataClearExtension.java
+++ b/src/test/java/com/vestie/vestie/common/DataClearExtension.java
@@ -1,0 +1,19 @@
+package com.vestie.vestie.common;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DataClearExtension implements AfterEachCallback {
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        DataCleaner dataCleaner = getDataCleaner(context);
+        dataCleaner.clear();
+    }
+
+    private DataCleaner getDataCleaner(ExtensionContext extensionContext) {
+        return SpringExtension.getApplicationContext(extensionContext)
+                .getBean(DataCleaner.class);
+    }
+}

--- a/src/test/java/com/vestie/vestie/member/application/MemberServiceTest.java
+++ b/src/test/java/com/vestie/vestie/member/application/MemberServiceTest.java
@@ -57,6 +57,8 @@ class MemberServiceTest {
 
             // when & then
             assertDoesNotThrow(() -> memberService.signUp(command));
+            assertThat(memberRepository.findById(1L))
+                    .isPresent();
         }
     }
 }

--- a/src/test/java/com/vestie/vestie/member/application/MemberServiceTest.java
+++ b/src/test/java/com/vestie/vestie/member/application/MemberServiceTest.java
@@ -1,0 +1,62 @@
+package com.vestie.vestie.member.application;
+
+import static com.vestie.vestie.member.exception.MemberExceptionType.DUPLICATE_USERNAME;
+import static com.vestie.vestie.member.fixture.MemberFixture.동훈;
+import static com.vestie.vestie.member.fixture.MemberFixture.동훈_비밀번호;
+import static com.vestie.vestie.member.fixture.MemberFixture.동훈_아이디;
+import static com.vestie.vestie.member.fixture.MemberFixture.동훈_이름;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.vestie.vestie.common.exception.BaseExceptionType;
+import com.vestie.vestie.member.application.dto.SignUpCommand;
+import com.vestie.vestie.member.domain.FakeMemberRepository;
+import com.vestie.vestie.member.domain.Member;
+import com.vestie.vestie.member.domain.MemberRepository;
+import com.vestie.vestie.member.domain.MemberValidator;
+import com.vestie.vestie.member.exception.MemberException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MemberService 은(는)")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MemberServiceTest {
+
+    private final MemberRepository memberRepository = new FakeMemberRepository();
+    private final MemberValidator memberValidator = new MemberValidator(memberRepository);
+    private final MemberService memberService = new MemberService(memberRepository, memberValidator);
+
+    @Nested
+    class 회원가입_시 {
+
+        @Test
+        void 중복된_아이디가_있으면_오류() {
+            // given
+            Member 동훈 = 동훈();
+            memberRepository.save(동훈);
+            SignUpCommand command = new SignUpCommand(동훈.username(), "password", "name");
+
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(MemberException.class, () ->
+                    memberService.signUp(command)
+            ).exceptionType();
+
+            // then
+            assertThat(baseExceptionType).isEqualTo(DUPLICATE_USERNAME);
+        }
+
+        @Test
+        void 아이디가_중복되지_않으면_생성된다() {
+            // given
+            SignUpCommand command = new SignUpCommand(동훈_아이디, 동훈_비밀번호, 동훈_이름);
+
+            // when & then
+            assertDoesNotThrow(() -> memberService.signUp(command));
+        }
+    }
+}

--- a/src/test/java/com/vestie/vestie/member/domain/FakeMemberRepository.java
+++ b/src/test/java/com/vestie/vestie/member/domain/FakeMemberRepository.java
@@ -1,0 +1,30 @@
+package com.vestie.vestie.member.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeMemberRepository implements MemberRepository {
+
+    private final Map<Long, Member> store = new HashMap<>();
+    private Long id = 1L;
+
+    @Override
+    public Member save(Member member) {
+        ReflectionTestUtils.setField(member, "id", id);
+        return store.put(id++, member);
+    }
+
+    @Override
+    public boolean existsByUsername(String username) {
+        return store.values()
+                .stream()
+                .anyMatch(it -> it.username().equals(username));
+    }
+
+    @Override
+    public Optional<Member> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+}

--- a/src/test/java/com/vestie/vestie/member/domain/MemberTest.java
+++ b/src/test/java/com/vestie/vestie/member/domain/MemberTest.java
@@ -1,0 +1,54 @@
+package com.vestie.vestie.member.domain;
+
+import static com.vestie.vestie.member.exception.MemberExceptionType.DUPLICATE_USERNAME;
+import static com.vestie.vestie.member.fixture.MemberFixture.동훈;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.vestie.vestie.common.exception.BaseExceptionType;
+import com.vestie.vestie.member.exception.MemberException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Member 은(는)")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MemberTest {
+
+    private final MemberRepository memberRepository = new FakeMemberRepository();
+    private final MemberValidator memberValidator = new MemberValidator(memberRepository);
+
+    @Nested
+    class 회원가입_시 {
+
+        @Test
+        void 중복된_아이디가_있으면_오류() {
+            // given
+            Member 이미_가입한_회원 = 동훈();
+            memberRepository.save(이미_가입한_회원);
+
+            Member 가입할_회원 = 동훈();
+
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(MemberException.class, () ->
+                    가입할_회원.signUp(memberValidator)
+            ).exceptionType();
+
+            // then
+            assertThat(baseExceptionType).isEqualTo(DUPLICATE_USERNAME);
+        }
+
+        @Test
+        void 아이디가_중복되지_않으면_생성된다() {
+            // given
+            Member 가입할_회원 = 동훈();
+
+            // when & then
+            assertDoesNotThrow(() -> 가입할_회원.signUp(memberValidator));
+        }
+    }
+}

--- a/src/test/java/com/vestie/vestie/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/vestie/vestie/member/domain/MemberValidatorTest.java
@@ -1,0 +1,53 @@
+package com.vestie.vestie.member.domain;
+
+import static com.vestie.vestie.member.exception.MemberExceptionType.DUPLICATE_USERNAME;
+import static com.vestie.vestie.member.fixture.MemberFixture.동훈;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.vestie.vestie.common.exception.BaseExceptionType;
+import com.vestie.vestie.member.exception.MemberException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MemberValidator 은(는)")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MemberValidatorTest {
+
+    private final MemberRepository memberRepository = new FakeMemberRepository();
+    private final MemberValidator validator = new MemberValidator(memberRepository);
+
+    @Nested
+    class 아이디_중복검사_시 {
+
+        @Test
+        void 해당_아이디로_가입한_회원이_있으면_예외() {
+            // given
+            Member 동훈 = 동훈();
+            memberRepository.save(동훈);
+
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(MemberException.class, () ->
+                    validator.validateDuplicateUsername(동훈.username())
+            ).exceptionType();
+
+            // then
+            assertThat(baseExceptionType).isEqualTo(DUPLICATE_USERNAME);
+        }
+
+        @Test
+        void 해당_아이디로_가입한_회원이_없으면_예외가_발생하지_않는다() {
+            // given
+            String uniqueUsername = "유일한 아이디";
+
+            // when & then
+            assertDoesNotThrow(() ->
+                    validator.validateDuplicateUsername(uniqueUsername));
+        }
+    }
+}

--- a/src/test/java/com/vestie/vestie/member/fixture/MemberFixture.java
+++ b/src/test/java/com/vestie/vestie/member/fixture/MemberFixture.java
@@ -1,0 +1,19 @@
+package com.vestie.vestie.member.fixture;
+
+import com.vestie.vestie.member.domain.Member;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberFixture {
+
+    public static final String 동훈_아이디 = "mallang";
+    public static final String 동훈_비밀번호 = "1234";
+    public static final String 동훈_이름 = "신동훈";
+
+    public static Member 동훈() {
+        return Member.builder()
+                .username(동훈_아이디)
+                .password(동훈_비밀번호)
+                .name(동훈_이름)
+                .build();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  profiles:
+    active: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+
+  jpa:
+    open-in-view: false
+    show_sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+        default_batch_fetch_size: 100
+    hibernate:
+      ddl-auto: create
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
- 테스트용 `Fake` 객체 생성을 위해 `MemberRepository`를 `JpaMemberRepository`에서 상속하도록 변경
- 회원가입 기능 구현
- 도메인 로직 단위테스트
- 서비스 로직 단위테스트
- 공통 인수 테스트 추상 클래스 작성
- 인수테스트에서 작성할 데이터베이스의 데이터 초기화 클래스 (`DataCleaner`, `DataClearExtension`) 작성
- 회원가입 인수 테스트 작성

close #7, #8
